### PR TITLE
MANTA-5112 muskie docs fallout from log file changes by MANTA-1936

### DIFF
--- a/0001-incident-response.adoc
+++ b/0001-incident-response.adoc
@@ -405,7 +405,7 @@ processed this request.
 +
 [source,text]
 ----
-manta-oneach -z WEBAPI_ZONE_UUID 'grep REQUEST_ID /var/log/muskie.log' | bunyan
+manta-oneach -z WEBAPI_ZONE_UUID 'svcs -L muskie | xargs cat | grep REQUEST_ID' | bunyan
 ----
 +
 filling in `WEBAPI_ZONE_UUID` from the `x-server-name` header and `REQUEST_ID`
@@ -453,7 +453,7 @@ log entry.
 +
 [source,text]
 ----
-manta-oneach -s webapi 'grep REQUEST_ID /var/log/muskie.log' | bunyan
+manta-oneach -s webapi 'svcs -L muskie | xargs cat | grep REQUEST_ID' | bunyan
 ----
 +
 ** **No, the request was handled earlier than that.**  Use a job to search

--- a/0002-investigation-tasks.adoc
+++ b/0002-investigation-tasks.adoc
@@ -255,7 +255,7 @@ details.  The `manta-oneach` command can be used as a low-level way to scan
 these real-time logs.  For example, a common way to count recent 500-level
 errors in webapi logs is:
 
-    manta-oneach --service=webapi 'grep -c "handled: 5" /var/log/muskie.log'
+    manta-oneach --service=webapi 'svcs -L muskie | xargs cat | grep -c "handled: 5"'
 
 Since the real-time logs only store the current hour's data, at 01:02Z, this
 would only scan 2 minutes worth of data.  At 01:58Z, this would scan 58 minutes


### PR DESCRIPTION
This updates the documentation to find all muskie service log files.

Note: this repo requires `asciidoctor` to build the HTML files.  I installed it but my version is a lot newer and made a *lot* of changes.  I can push those changes, or someone with an older version of ascii doctor can build the HTML files.